### PR TITLE
Criação dos Filtros de Cinemas

### DIFF
--- a/FiltroCinemas.hpp
+++ b/FiltroCinemas.hpp
@@ -2,12 +2,14 @@
 #include "Filme.hpp"
 #include "Cinema.h"
 #include <iostream>
+#include <cmath>
+
 using namespace std;
 
 class FiltroCinemas
 {
 public:
-    void filtroCinemaPorTipoFilme(vector<Cinema> &cinemas, const vector<string> &tiposDesejados)
+    void filtroCinemasPorTipoFilme(vector<Cinema> &cinemas, const vector<string> &tiposDesejados)
     {
         vector<Cinema> filtrados;
 
@@ -37,7 +39,7 @@ public:
         cinemas = filtrados;
     }
 
-    void filtroCinemaPorGeneroFilme(vector<Cinema> &cinemas, const vector<string> &generosBuscados)
+    void filtroCinemasPorGeneroFilme(vector<Cinema> &cinemas, const vector<string> &generosBuscados)
     {
         vector<Cinema> filtrados;
 
@@ -68,6 +70,84 @@ public:
 
             if (contemGenero)
             {
+                filtrados.push_back(cinema);
+            }
+        }
+
+        cinemas = filtrados;
+    }
+
+    void filtroCinemasPorDuracaoFilme(vector<Cinema> &cinemas, int minDuracao, int maxDuracao)
+    {
+        vector<Cinema> filtrados;
+
+        for (const Cinema &cinema : cinemas)
+        {
+            bool contemDuracaoValida = false;
+
+            for (const Filme &f : cinema.filmesEmExibicao)
+            {
+                if (f.runtimeMinutes >= minDuracao && f.runtimeMinutes <= maxDuracao)
+                {
+                    contemDuracaoValida = true;
+                    break;
+                }
+            }
+
+            if (contemDuracaoValida)
+            {
+                filtrados.push_back(cinema);
+            }
+        }
+
+        cinemas = filtrados;
+    }
+
+    void filtroCinemasPorLocalizacao(vector<Cinema> &cinemas, int usuarioX, int usuarioY, float raio)
+    {
+        vector<Cinema> filtrados;
+
+        for (const Cinema &cinema : cinemas)
+        {
+            float dx = cinema.coordenadaX - usuarioX;
+            float dy = cinema.coordenadaY - usuarioY;
+            float distancia = sqrt(dx * dx + dy * dy);
+
+            if (distancia <= raio)
+            {
+                filtrados.push_back(cinema);
+            }
+        }
+
+        cinemas = filtrados;
+    }
+
+    void filtroCinemasPorPreco(vector<Cinema>& cinemas, double precoMaximo) {
+        vector<Cinema> filtrados;
+
+        for (const Cinema& cinema : cinemas) {
+            if (cinema.precoIngresso <= precoMaximo) {
+                filtrados.push_back(cinema);
+            }
+        }
+
+        cinemas = filtrados;
+    }
+    
+    void filtroCinemasPorAnoFilme(vector<Cinema>& cinemas, int anoMin, int anoMax) {
+        vector<Cinema> filtrados;
+
+        for (const Cinema& cinema : cinemas) {
+            bool contemAnoValido = false;
+
+            for (const Filme& f : cinema.filmesEmExibicao) {
+                if (f.startYear >= anoMin && f.startYear <= anoMax) {
+                    contemAnoValido = true;
+                    break;
+                }
+            }
+
+            if (contemAnoValido) {
                 filtrados.push_back(cinema);
             }
         }


### PR DESCRIPTION
Este pull request implementa a classe FiltroCinemas, responsável por realizar filtros em uma lista de cinemas com base em diferentes critérios. Os seguintes métodos foram adicionados:

filtroCinemasPorTipoFilme – Filtra cinemas que exibem filmes de tipos específicos.

filtroCinemasPorGeneroFilme – Filtra cinemas que exibem filmes com pelo menos um dos gêneros desejados.

filtroCinemasPorDuracaoFilme – Filtra cinemas com filmes em exibição cuja duração está dentro de um intervalo fornecido.

filtroCinemasPorLocalizacao – Filtra cinemas que estão dentro de um raio (distância euclidiana) a partir da localização do usuário.

filtroCinemasPorPreco – Filtra cinemas cujo preço de ingresso é menor ou igual a um valor máximo.

filtroCinemasPorAnoFilme – Filtra cinemas que exibem filmes lançados em um ano específico ou intervalo de anos.

